### PR TITLE
skill bar length tweak

### DIFF
--- a/src/components/DamageMeter/SkillEntry.vue
+++ b/src/components/DamageMeter/SkillEntry.vue
@@ -20,7 +20,7 @@
     <div
       class="player-bar"
       :style="`
-              width:${skill.damagePercent}%;
+              width:${skill.relativePercent}%;
               background:${getClassColor(className)};}
               `"
     ></div>

--- a/src/layouts/DamageMeter.vue
+++ b/src/layouts/DamageMeter.vue
@@ -256,6 +256,10 @@ function calculateSkills() {
       (skill.totalDamage / entity.damageDealt) *
       100
     ).toFixed(1);
+    skill.relativePercent = (
+      (skill.totalDamage / res[0].totalDamage ) *
+      100
+    ).toFixed(1);
   }
 
   sortedSkills.value = res;


### PR DESCRIPTION
Skill bar length is now based on their relative values instead of their damage%

If too many skills were used, the bars were too small

[preview](https://imgur.com/a/RV3pVRk)

it adds clarity
