### PR TITLE
Add Open Folder Button to Logs View

### DIFF
--- a/src-electron/electron-main.js
+++ b/src-electron/electron-main.js
@@ -32,7 +32,7 @@ import {
 
 import { SessionState } from "./session-state";
 
-import { parseLogs, getParsedLogs, getLogData } from "./log-files/helper";
+import { parseLogs, getParsedLogs, getLogData, getLogDirectory } from "./log-files/helper";
 
 const store = new Store();
 
@@ -241,6 +241,9 @@ ipcMain.on("window-to-main", (event, arg) => {
     parseLogs();
     const parsedLogs = getParsedLogs();
     event.reply("parsed-logs-list", parsedLogs);
+  } else if (arg.message === "open-log-directory") {
+    const parsedLogFolder = getLogDirectory();
+    shell.openPath(parsedLogFolder);
   } else if (arg.message === "get-parsed-log") {
     const logData = getLogData(arg.value);
     event.reply("parsed-log", logData);

--- a/src-electron/log-files/helper.js
+++ b/src-electron/log-files/helper.js
@@ -96,3 +96,8 @@ export function getLogData(filename) {
   );
   return JSON.parse(contents);
 }
+
+
+export function getLogDirectory() {
+  return parsedLogFolder;
+}

--- a/src/pages/LogsPage.vue
+++ b/src/pages/LogsPage.vue
@@ -26,6 +26,13 @@
           style="margin-left: auto"
           unelevated
           color="primary"
+          label="Open Folder"
+          @click="openLogDirectory"
+        />
+        <q-btn
+          style="margin-left: auto"
+          unelevated
+          color="primary"
           label="Refresh"
           @click="getLogfiles"
         />
@@ -142,6 +149,10 @@ function onPagination(newPagination) {
 function getLogfiles() {
   logFiles.value = [];
   window.messageApi.send("window-to-main", { message: "get-parsed-logs" });
+}
+
+function openLogDirectory() {
+  window.messageApi.send("window-to-main", { message: "open-log-directory" });
 }
 
 onMounted(() => {


### PR DESCRIPTION
Adds a button to the log view so as to open that folder up and explore it. Particularly helpful if uploading to an external log viewing site like [this one](https://marsunpaisti.github.io/LostArkLogVisualizer/).

I don't have any dev tools on my gaming (Windows) machine so I couldn't test this, I'd appreciate having this branch pulled and compiled to see if it works ty <3