### PR TITLE
Fix Arcanist Naming

### DIFF
--- a/src/constants/classes.js
+++ b/src/constants/classes.js
@@ -1,5 +1,5 @@
 export const classes = {
-  Arcanist: { color: "#b38915" },
+  Arcana: { color: "#b38915" },
   Artillerist: { color: "#33670b" },
   Assassin: { color: "#3752d8" },
   Bard: { color: "#674598" },


### PR DESCRIPTION
Fixes Arcanist not showing up correctly in DPS meter view.  

This isn't necessarily the best solution as any time the name of a class or skill differs from what LostArkLogger sends it may end up not displaying correctly. I would consider switching from using names to index data, to the actual IDs i.e.: instead of "Berserker", use "102".

I'm down to send another PR with this included, but after skimming over what would be required this might cause more issues than it solves so I'd appreciate your feedback.